### PR TITLE
feat: Add cost_class details to `get_places_costs()` output (SNT-225)

### DIFF
--- a/scripts/performance_test.py
+++ b/scripts/performance_test.py
@@ -1,0 +1,161 @@
+"""
+Performance test for BudgetCalculator.
+
+Usage: python performance_test.py
+"""
+
+import time
+import pandas as pd
+from snt_malaria_budgeting.core.budget_calculator import BudgetCalculator
+from snt_malaria_budgeting.models import (
+    DEFAULT_COST_ASSUMPTIONS,
+    InterventionDetailModel,
+)
+
+POP_TOTAL = 250000
+POP_PW = 12500
+POP_0_5 = 45000
+POP_0_1 = 10000
+POP_1_2 = 10000
+POP_VACCINE_5_36_MONTHS = 8000
+
+
+def create_large_dataset(num_places, num_years):
+    data = []
+    base_key = 2000
+    for place_idx in range(num_places):
+        key = base_key + place_idx
+        multiplier = (place_idx % 5) + 1
+        for year_idx in range(num_years):
+            year = 2025 + year_idx
+            data.append(
+                {
+                    "key": key,
+                    "year": year,
+                    "pop_total": POP_TOTAL * multiplier,
+                    "pop_pw": POP_PW * multiplier,
+                    "pop_0_5": POP_0_5 * multiplier,
+                    "pop_0_1": POP_0_1 * multiplier,
+                    "pop_1_2": POP_1_2 * multiplier,
+                    "pop_vaccine_5_36_months": POP_VACCINE_5_36_MONTHS * multiplier,
+                }
+            )
+    return pd.DataFrame(data)
+
+
+def create_cost_data(num_years):
+    data = []
+    intervention_types = [
+        ("iptp", "SP", "per SP", "Commodity"),
+        ("iptp", "SP", "per SP", "Distribution"),
+        ("smc", "SP+AQ", "per SPAQ pack 3-11 month olds", "Commodity"),
+        ("smc", "SP+AQ", "per SPAQ pack 12-59 month olds", "Commodity"),
+        ("smc", "SP+AQ", "per SPAQ pack 3-11 month olds", "Distribution"),
+        ("smc", "SP+AQ", "per SPAQ pack 12-59 month olds", "Distribution"),
+        ("pmc", "SP", "per SP", "Commodity"),
+        ("pmc", "SP", "per SP", "Distribution"),
+        ("itn_routine", "PBO", "per ITN", "Procurement"),
+        ("itn_routine", "PBO", "per ITN", "Distribution"),
+        ("itn_routine", "Standard Pyrethroid", "per ITN", "Procurement"),
+        ("itn_routine", "Standard Pyrethroid", "per ITN", "Distribution"),
+        ("itn_campaign", "Dual AI", "per ITN", "Procurement"),
+        ("itn_campaign", "Dual AI", "per ITN", "Distribution"),
+        ("itn_campaign", "Dual AI", "per bale", "Distribution"),
+        ("vacc", "R21", "per dose", "Commodity"),
+        ("vacc", "R21", "per dose", "Distribution"),
+        ("vacc", "RTS,S", "per dose", "Commodity"),
+        ("vacc", "RTS,S", "per dose", "Distribution"),
+    ]
+    for year_idx in range(num_years):
+        year = 2025 + year_idx
+        for code, type_int, unit, cost_class in intervention_types:
+            base_usd = 0.5 + (year_idx * 0.1)
+            base_ngn = 800 + (year_idx * 50)
+            data.append(
+                {
+                    "code_intervention": code,
+                    "type_intervention": type_int,
+                    "unit": unit,
+                    "cost_class": cost_class,
+                    "cost_year_for_analysis": year,
+                    "usd_cost": base_usd,
+                    "ngn_cost": base_ngn,
+                    "cost_name": f"{type_int} - {cost_class}",
+                }
+            )
+    return pd.DataFrame(data)
+
+
+def create_interventions(num_places):
+    base_key = 2000
+    places = [base_key + i for i in range(num_places)]
+    third = num_places // 3
+    return [
+        InterventionDetailModel(code="iptp", type="SP", places=places),
+        InterventionDetailModel(code="smc", type="SP+AQ", places=places[:third]),
+        InterventionDetailModel(
+            code="pmc", type="SP", places=places[third : third * 2]
+        ),
+        InterventionDetailModel(
+            code="itn_routine", type="PBO", places=places[: third * 2]
+        ),
+        InterventionDetailModel(
+            code="itn_routine", type="Standard Pyrethroid", places=places[third * 2 :]
+        ),
+        InterventionDetailModel(code="itn_campaign", type="Dual AI", places=places),
+        InterventionDetailModel(code="vacc", type="R21", places=places[:third]),
+        InterventionDetailModel(
+            code="vacc", type="RTS,S", places=places[third : third * 2]
+        ),
+    ]
+
+
+def benchmark(method, *args):
+    start = time.time()
+    result = method(*args)
+    return time.time() - start, result
+
+
+def run_performance_test(num_places, num_years):
+    population_df = create_large_dataset(num_places, num_years)
+    cost_df = create_cost_data(num_years)
+    interventions = create_interventions(num_places)
+
+    calculator = BudgetCalculator(
+        interventions_input=interventions,
+        settings=DEFAULT_COST_ASSUMPTIONS,
+        cost_df=cost_df,
+        population_df=population_df,
+        local_currency="ngn",
+        spatial_planning_unit="key",
+        budget_currency="usd",
+    )
+
+    t_interventions = 0
+    t_places = 0
+    for year in range(2025, 2025 + num_years):
+        t, _ = benchmark(calculator.get_interventions_costs, year)
+        t_interventions += t
+        t, _ = benchmark(calculator.get_places_costs, year)
+        t_places += t
+
+    return t_interventions, t_places
+
+
+def main():
+    configs = [("100 places", 100, 5), ("500 places", 500, 5)]
+
+    print(
+        f"{'Config':<12} {'interv_costs':>12} {'places_costs':>12} {'total (5Ys)':>8} {'avg/yr':>8}"
+    )
+    print("-" * 56)
+
+    for label, num_places, num_years in configs:
+        t_int, t_pl = run_performance_test(num_places, num_years)
+        total = t_int + t_pl
+        avg = total / num_years
+        print(f"{label:<12} {t_int:>11.3f}s {t_pl:>11.3f}s {total:>7.3f}s {avg:>7.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/snt_malaria_budgeting/core/budget_calculator.py
+++ b/snt_malaria_budgeting/core/budget_calculator.py
@@ -152,9 +152,10 @@ class BudgetCalculator:
         for place in self.places:
             interventions_list = []
             if place in places_with_interventions:
-                for (type_intervention, code_intervention), cost in (
-                    grouped_per_place_and_intervention[place].items()
-                ):
+                for (
+                    type_intervention,
+                    code_intervention,
+                ), cost in grouped_per_place_and_intervention[place].items():
                     if cost > 0:
                         interventions_list.append(
                             {
@@ -168,9 +169,7 @@ class BudgetCalculator:
             if place in places_with_cost_classes:
                 for cost_class, cost in place_cost_class_totals[place].items():
                     if cost > 0:
-                        cost_breakdown.append(
-                            {"cost_class": cost_class, "cost": cost}
-                        )
+                        cost_breakdown.append({"cost_class": cost_class, "cost": cost})
 
             place_costs.append(
                 {

--- a/snt_malaria_budgeting/core/budget_calculator.py
+++ b/snt_malaria_budgeting/core/budget_calculator.py
@@ -140,6 +140,11 @@ class BudgetCalculator:
             "cost_element"
         ].sum()
 
+        # get costs per place and cost_class
+        place_cost_class_totals = budget_filtered_by_currency.groupby(
+            [self.spatial_planning_unit, "cost_class"]
+        )["cost_element"].sum()
+
         place_costs = []
         for place in self.places:
             place_interventions = grouped_per_place_and_intervention[
@@ -157,10 +162,20 @@ class BudgetCalculator:
                             "total_cost": row["cost_element"],
                         }
                     )
+
+            cost_breakdown = []
+            if place in place_cost_class_totals.index.get_level_values(0):
+                for cost_class, cost in place_cost_class_totals[place].items():
+                    if cost > 0:
+                        cost_breakdown.append(
+                            {"cost_class": cost_class, "cost": cost}
+                        )
+
             place_costs.append(
                 {
                     "place": place,
                     "total_cost": place_totals.get(place, 0),
+                    "cost_breakdown": cost_breakdown,
                     "interventions": interventions_list,
                 }
             )

--- a/snt_malaria_budgeting/core/budget_calculator.py
+++ b/snt_malaria_budgeting/core/budget_calculator.py
@@ -127,13 +127,9 @@ class BudgetCalculator:
         ]
 
         # Group to have cost per place and intervention type and code
-        grouped_per_place_and_intervention = (
-            budget_filtered_by_currency.groupby(
-                [self.spatial_planning_unit, "type_intervention", "code_intervention"]
-            )
-            .sum()
-            .reset_index()
-        )
+        grouped_per_place_and_intervention = budget_filtered_by_currency.groupby(
+            [self.spatial_planning_unit, "type_intervention", "code_intervention"]
+        )["cost_element"].sum()
 
         # get total costs per place
         place_totals = budget_filtered_by_currency.groupby(self.spatial_planning_unit)[
@@ -145,26 +141,31 @@ class BudgetCalculator:
             [self.spatial_planning_unit, "cost_class"]
         )["cost_element"].sum()
 
+        places_with_interventions = set(
+            grouped_per_place_and_intervention.index.get_level_values(0)
+        )
+        places_with_cost_classes = set(
+            place_cost_class_totals.index.get_level_values(0)
+        )
+
         place_costs = []
         for place in self.places:
-            place_interventions = grouped_per_place_and_intervention[
-                grouped_per_place_and_intervention[self.spatial_planning_unit] == place
-            ]
-
             interventions_list = []
-
-            for _, row in place_interventions.iterrows():
-                if row["cost_element"] > 0:
-                    interventions_list.append(
-                        {
-                            "type": row["type_intervention"],
-                            "code": row["code_intervention"],
-                            "total_cost": row["cost_element"],
-                        }
-                    )
+            if place in places_with_interventions:
+                for (type_intervention, code_intervention), cost in (
+                    grouped_per_place_and_intervention[place].items()
+                ):
+                    if cost > 0:
+                        interventions_list.append(
+                            {
+                                "type": type_intervention,
+                                "code": code_intervention,
+                                "total_cost": cost,
+                            }
+                        )
 
             cost_breakdown = []
-            if place in place_cost_class_totals.index.get_level_values(0):
+            if place in places_with_cost_classes:
                 for cost_class, cost in place_cost_class_totals[place].items():
                     if cost > 0:
                         cost_breakdown.append(

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -80,6 +80,9 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_iptp_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost)
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -131,6 +134,9 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_iptp_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost)
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -262,6 +268,11 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_itn_campaign_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Procurement")
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_itn_campaign_cost
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "PBO")
@@ -346,6 +357,9 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_smc_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_smc_cost)
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP+AQ")
@@ -424,6 +438,9 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_pmc_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_pmc_cost)
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -489,6 +506,9 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_vacc_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_vacc_cost)
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "R21")
@@ -602,6 +622,11 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(
             place_1001["total_cost"], correct_iptp_cost_location_1001
         )
+        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
+        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1001
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -615,6 +640,12 @@ class TestGetBudget(unittest.TestCase):
         )
         self.assertAlmostEqual(
             place_1002["total_cost"], correct_iptp_cost_location_1002 + correct_smc_cost
+        )
+        self.assertEqual(len(place_1002["cost_breakdown"]), 1)
+        self.assertEqual(place_1002["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_1002["cost_breakdown"][0]["cost"],
+            correct_iptp_cost_location_1002 + correct_smc_cost,
         )
         self.assertEqual(len(place_1002["interventions"]), 2)
         place_iptp = place_1002["interventions"][0]

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -82,7 +82,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_1001["total_cost"], correct_iptp_cost)
         self.assertEqual(len(place_1001["cost_breakdown"]), 1)
         self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost)
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -136,7 +138,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_1001["total_cost"], correct_iptp_cost)
         self.assertEqual(len(place_1001["cost_breakdown"]), 1)
         self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost)
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -359,7 +363,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_1001["total_cost"], correct_smc_cost)
         self.assertEqual(len(place_1001["cost_breakdown"]), 1)
         self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_smc_cost)
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_smc_cost
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP+AQ")
@@ -440,7 +446,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_1001["total_cost"], correct_pmc_cost)
         self.assertEqual(len(place_1001["cost_breakdown"]), 1)
         self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_pmc_cost)
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_pmc_cost
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -508,7 +516,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_1001["total_cost"], correct_vacc_cost)
         self.assertEqual(len(place_1001["cost_breakdown"]), 1)
         self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_1001["cost_breakdown"][0]["cost"], correct_vacc_cost)
+        self.assertAlmostEqual(
+            place_1001["cost_breakdown"][0]["cost"], correct_vacc_cost
+        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "R21")

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -188,7 +188,7 @@ class TestGetBudget(unittest.TestCase):
         correct_pbo_target_pop = POP_PW + POP_0_5
         correct_target_pbo_cost = 3.49 * correct_pbo_target_pop * 0.3 * 1.1
 
-        # formula: pop * coverage * doses * buffer
+        # formula: pop * coverage * buffer
         self.assertAlmostEqual(pbo_budget["total_pop"], correct_pbo_target_pop)
         self.assertAlmostEqual(pbo_budget["total_cost"], correct_target_pbo_cost)
         self.assertEqual(pbo_budget["type"], "PBO")
@@ -789,3 +789,60 @@ class TestGetBudget(unittest.TestCase):
                 )
             else:
                 self.fail("Unexpected cost_class in itn_campaign cost_breakdown")
+
+    def test_get_places_costs_multiple_cost_classes(self):
+        interventions = [
+            InterventionDetailModel(code="itn_routine", type="Dual AI", places=[1001])
+        ]
+
+        cost_df = pd.DataFrame(
+            {
+                "code_intervention": ["itn_routine", "itn_routine", "itn_routine"],
+                "type_intervention": ["Dual AI", "Dual AI", "Dual AI"],
+                "unit": ["per ITN", "per ITN", "per ITN"],
+                "cost_class": ["Procurement", "Distribution", "Operational"],
+                "cost_year_for_analysis": [2025, 2025, 2025],
+                "usd_cost": [3.49, 0.36, 0.15],
+                "local_currency_cost": [1, 1, 1],
+            }
+        )
+
+        budget_calculator = BudgetCalculator(
+            interventions_input=interventions,
+            settings=DEFAULT_COST_ASSUMPTIONS,
+            cost_df=cost_df,
+            population_df=self.population_df,
+            local_currency="ngn",
+            spatial_planning_unit="key",
+            budget_currency="usd",
+        )
+
+        places_costs = budget_calculator.get_places_costs(2025)
+
+        # formula: pop * coverage * buffer
+        correct_multiplier = (POP_PW + POP_0_5) * 0.3 * 1.1
+        correct_procurement_cost = 3.49 * correct_multiplier
+        correct_distribution_cost = 0.36 * correct_multiplier
+        correct_operational_cost = 0.15 * correct_multiplier
+        correct_total_cost = (
+            correct_procurement_cost
+            + correct_distribution_cost
+            + correct_operational_cost
+        )
+
+        place_1001 = next(
+            place_cost for place_cost in places_costs if place_cost["place"] == 1001
+        )
+        self.assertAlmostEqual(place_1001["total_cost"], correct_total_cost)
+        self.assertEqual(len(place_1001["cost_breakdown"]), 3)
+        for cost_breakdown in place_1001["cost_breakdown"]:
+            if cost_breakdown["cost_class"] == "Procurement":
+                self.assertAlmostEqual(cost_breakdown["cost"], correct_procurement_cost)
+            elif cost_breakdown["cost_class"] == "Distribution":
+                self.assertAlmostEqual(
+                    cost_breakdown["cost"], correct_distribution_cost
+                )
+            elif cost_breakdown["cost_class"] == "Operational":
+                self.assertAlmostEqual(cost_breakdown["cost"], correct_operational_cost)
+            else:
+                self.fail("Unexpected cost_class in place cost_breakdown")


### PR DESCRIPTION
(Non-breaking) changes:

- Add details about the cost classes to the result of the `get_places_costs()` method:
```python
    {
        "place": 1071,
        "total_cost": 238501.72710000005,
        "interventions": [
            {"type": "R21", "code": "vacc", "total_cost": 238501.72710000005}
        ],
        # Additional payload:
        "cost_breakdown": [
            {"cost_class": "Operational", "cost": 12822.6735},
            {"cost_class": "Procurement", "cost": 225679.05360000004},
        ],
    },
```
- Small refactoring to make sure performance is not degraded + added a little test script for this.