### PR TITLE
feat: Add full cost_class details per intervention to `get_places_costs()` output (SNT-225)

### DIFF
--- a/snt_malaria_budgeting/core/budget_calculator.py
+++ b/snt_malaria_budgeting/core/budget_calculator.py
@@ -126,9 +126,14 @@ class BudgetCalculator:
             budget["currency"] == self.budget_currency.upper()
         ]
 
-        # Group to have cost per place and intervention type and code
-        grouped_per_place_and_intervention = budget_filtered_by_currency.groupby(
-            [self.spatial_planning_unit, "type_intervention", "code_intervention"]
+        # Group to have cost per place, intervention type/code, and cost_class
+        grouped_per_place_intervention_class = budget_filtered_by_currency.groupby(
+            [
+                self.spatial_planning_unit,
+                "type_intervention",
+                "code_intervention",
+                "cost_class",
+            ]
         )["cost_element"].sum()
 
         # get total costs per place
@@ -136,49 +141,46 @@ class BudgetCalculator:
             "cost_element"
         ].sum()
 
-        # get costs per place and cost_class
-        place_cost_class_totals = budget_filtered_by_currency.groupby(
-            [self.spatial_planning_unit, "cost_class"]
-        )["cost_element"].sum()
-
-        places_with_interventions = set(
-            grouped_per_place_and_intervention.index.get_level_values(0)
-        )
-        places_with_cost_classes = set(
-            place_cost_class_totals.index.get_level_values(0)
+        places_with_data = set(
+            grouped_per_place_intervention_class.index.get_level_values(0)
         )
 
         place_costs = []
         for place in self.places:
             interventions_list = []
-            if place in places_with_interventions:
+            if place in places_with_data:
+                place_data = grouped_per_place_intervention_class[place]
+                interventions_dict = {}
                 for (
                     type_intervention,
                     code_intervention,
-                ), cost in grouped_per_place_and_intervention[place].items():
+                    cost_class,
+                ), cost in place_data.items():
+                    key = (type_intervention, code_intervention)
+                    if key not in interventions_dict:
+                        interventions_dict[key] = {
+                            "type": type_intervention,
+                            "code": code_intervention,
+                            "total_cost": 0,
+                            "cost_breakdown": [],
+                        }
                     if cost > 0:
-                        interventions_list.append(
-                            {
-                                "type": type_intervention,
-                                "code": code_intervention,
-                                "total_cost": cost,
-                            }
+                        interventions_dict[key]["total_cost"] += cost
+                        interventions_dict[key]["cost_breakdown"].append(
+                            {"cost_class": cost_class, "cost": cost}
                         )
-
-            cost_breakdown = []
-            if place in places_with_cost_classes:
-                for cost_class, cost in place_cost_class_totals[place].items():
-                    if cost > 0:
-                        cost_breakdown.append({"cost_class": cost_class, "cost": cost})
+                interventions_list = [
+                    v for v in interventions_dict.values() if v["total_cost"] > 0
+                ]
 
             place_costs.append(
                 {
                     "place": place,
                     "total_cost": place_totals.get(place, 0),
-                    "cost_breakdown": cost_breakdown,
                     "interventions": interventions_list,
                 }
             )
+
         return place_costs
 
     def _get_scenario_data(

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -87,7 +87,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_iptp["total_cost"], correct_iptp_cost)
         self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
         self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost)
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost
+        )
 
     def test_get_budget_iptp(self):
         interventions = [InterventionDetailModel(code="iptp", type="SP", places=[1001])]
@@ -141,7 +143,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_iptp["total_cost"], correct_iptp_cost)
         self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
         self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost)
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost
+        )
 
     def test_get_budget_itn_routine(self):
         interventions = [
@@ -364,7 +368,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_iptp["total_cost"], correct_smc_cost)
         self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
         self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_smc_cost)
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_smc_cost
+        )
 
     def test_get_budget_pmc(self):
         interventions = [InterventionDetailModel(code="pmc", type="SP", places=[1001])]
@@ -445,7 +451,9 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_iptp["total_cost"], correct_pmc_cost)
         self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
         self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_pmc_cost)
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_pmc_cost
+        )
 
     def test_get_budget_vacc(self):
         interventions = [
@@ -661,9 +669,7 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(place_smc["total_cost"], correct_smc_cost)
         self.assertEqual(len(place_smc["cost_breakdown"]), 1)
         self.assertEqual(place_smc["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_smc["cost_breakdown"][0]["cost"], correct_smc_cost
-        )
+        self.assertAlmostEqual(place_smc["cost_breakdown"][0]["cost"], correct_smc_cost)
 
     def test_budget_itn(self):
         interventions = [

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -80,16 +80,14 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_iptp_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
         self.assertEqual(place_iptp["code"], "iptp")
         self.assertAlmostEqual(place_iptp["total_cost"], correct_iptp_cost)
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost)
 
     def test_get_budget_iptp(self):
         interventions = [InterventionDetailModel(code="iptp", type="SP", places=[1001])]
@@ -136,16 +134,14 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_iptp_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
         self.assertEqual(place_iptp["code"], "iptp")
         self.assertAlmostEqual(place_iptp["total_cost"], correct_iptp_cost)
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost)
 
     def test_get_budget_itn_routine(self):
         interventions = [
@@ -272,16 +268,16 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_itn_campaign_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Procurement")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_itn_campaign_cost
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "PBO")
         self.assertEqual(place_iptp["code"], "itn_campaign")
         self.assertAlmostEqual(place_iptp["total_cost"], correct_itn_campaign_cost)
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Procurement")
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_itn_campaign_cost
+        )
 
     def test_get_budget_smc(self):
         interventions = [
@@ -361,16 +357,14 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_smc_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_smc_cost
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP+AQ")
         self.assertEqual(place_iptp["code"], "smc")
         self.assertAlmostEqual(place_iptp["total_cost"], correct_smc_cost)
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_smc_cost)
 
     def test_get_budget_pmc(self):
         interventions = [InterventionDetailModel(code="pmc", type="SP", places=[1001])]
@@ -444,16 +438,14 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_pmc_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_pmc_cost
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
         self.assertEqual(place_iptp["code"], "pmc")
         self.assertAlmostEqual(place_iptp["total_cost"], correct_pmc_cost)
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_iptp["cost_breakdown"][0]["cost"], correct_pmc_cost)
 
     def test_get_budget_vacc(self):
         interventions = [
@@ -514,16 +506,16 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_vacc_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_vacc_cost
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "R21")
         self.assertEqual(place_iptp["code"], "vacc")
         self.assertAlmostEqual(place_iptp["total_cost"], correct_vacc_cost)
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_vacc_cost
+        )
 
     def test_get_budget_multiple_interventions(self):
         interventions = [
@@ -632,17 +624,17 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(
             place_1001["total_cost"], correct_iptp_cost_location_1001
         )
-        self.assertEqual(len(place_1001["cost_breakdown"]), 1)
-        self.assertEqual(place_1001["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1001["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1001
-        )
         self.assertEqual(len(place_1001["interventions"]), 1)
         place_iptp = place_1001["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
         self.assertEqual(place_iptp["code"], "iptp")
         self.assertAlmostEqual(
             place_iptp["total_cost"], correct_iptp_cost_location_1001
+        )
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1001
         )
 
         place_1002 = next(
@@ -651,12 +643,6 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(
             place_1002["total_cost"], correct_iptp_cost_location_1002 + correct_smc_cost
         )
-        self.assertEqual(len(place_1002["cost_breakdown"]), 1)
-        self.assertEqual(place_1002["cost_breakdown"][0]["cost_class"], "Commodity")
-        self.assertAlmostEqual(
-            place_1002["cost_breakdown"][0]["cost"],
-            correct_iptp_cost_location_1002 + correct_smc_cost,
-        )
         self.assertEqual(len(place_1002["interventions"]), 2)
         place_iptp = place_1002["interventions"][0]
         self.assertEqual(place_iptp["type"], "SP")
@@ -664,10 +650,20 @@ class TestGetBudget(unittest.TestCase):
         self.assertAlmostEqual(
             place_iptp["total_cost"], correct_iptp_cost_location_1002
         )
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1002
+        )
         place_smc = place_1002["interventions"][1]
         self.assertEqual(place_smc["type"], "SP+AQ")
         self.assertEqual(place_smc["code"], "smc")
         self.assertAlmostEqual(place_smc["total_cost"], correct_smc_cost)
+        self.assertEqual(len(place_smc["cost_breakdown"]), 1)
+        self.assertEqual(place_smc["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_smc["cost_breakdown"][0]["cost"], correct_smc_cost
+        )
 
     def test_budget_itn(self):
         interventions = [
@@ -834,8 +830,13 @@ class TestGetBudget(unittest.TestCase):
             place_cost for place_cost in places_costs if place_cost["place"] == 1001
         )
         self.assertAlmostEqual(place_1001["total_cost"], correct_total_cost)
-        self.assertEqual(len(place_1001["cost_breakdown"]), 3)
-        for cost_breakdown in place_1001["cost_breakdown"]:
+        self.assertEqual(len(place_1001["interventions"]), 1)
+        place_itn_routine = place_1001["interventions"][0]
+        self.assertEqual(place_itn_routine["type"], "Dual AI")
+        self.assertEqual(place_itn_routine["code"], "itn_routine")
+        self.assertAlmostEqual(place_itn_routine["total_cost"], correct_total_cost)
+        self.assertEqual(len(place_itn_routine["cost_breakdown"]), 3)
+        for cost_breakdown in place_itn_routine["cost_breakdown"]:
             if cost_breakdown["cost_class"] == "Procurement":
                 self.assertAlmostEqual(cost_breakdown["cost"], correct_procurement_cost)
             elif cost_breakdown["cost_class"] == "Distribution":
@@ -845,4 +846,4 @@ class TestGetBudget(unittest.TestCase):
             elif cost_breakdown["cost_class"] == "Operational":
                 self.assertAlmostEqual(cost_breakdown["cost"], correct_operational_cost)
             else:
-                self.fail("Unexpected cost_class in place cost_breakdown")
+                self.fail("Unexpected cost_class in itn_routine cost_breakdown")


### PR DESCRIPTION
Improvement over the first attempt (https://github.com/BLSQ/snt-malaria-budgeting/pull/38)

We basically add the full cost breakdown per OU to the payload, giving us full flexibility to display filtered graphs:
```python
{
    "place": 1071,
    "total_cost": 238501.72710000005,
    "interventions": [
        {
            "type": "R21",
            "code": "vacc",
            "total_cost": 238501.72710000005,
            # Additional payload:
            "cost_breakdown": [
                {"cost_class": "Operational", "cost": 12822.6735},
                {"cost_class": "Procurement", "cost": 225679.05360000004},
            ],
        }
    ],
}
```