### PR TITLE
SNT-216 the budget python package should support overriding target population for specific interventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ print(budgets)
 - **target_population_columns**: (Optional) List of population columns to use for quantification (e.g., ["pop_total"], ["pop_0_5", "pop_pw"])
 
 
-**Default target population columns by intervention:**
-
 **Default Target Population & Required Cost Units by Intervention:**
 
 | Intervention Code | Default Target Population Column(s) | Required Cost Unit(s)                |
@@ -91,11 +89,6 @@ print(budgets)
 > **Note:**
 > - The `unit` column in your `cost_df` must match the required cost unit(s) for each intervention code above.
 > - Some interventions (like SMC and Vacc) require multiple units for different age groups or quantification types.
-
-> **Note:**
-> - The `unit` column in your `cost_df` must match the required cost unit(s) for each intervention code above.
-> - Some interventions (like SMC and Vacc) require multiple units for different age groups or quantification types.
-
 
 
 ### 2. `settings` (Dictionary)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ budget_calculator = BudgetCalculator(
     local_currency="EUR",
     spatial_planning_unit="key",
     cost_overrides=[], # optional
+    unknown_intervention_handling="ignore", #optional can be: ignore, handle or error
 
 )
 
@@ -62,6 +63,76 @@ for year in range(start_year, end_year + 1):
 print(budgets)
 
 ```
+
+
+## Input Definitions
+
+### 1. `interventions_input` (List of `InterventionDetailModel`)
+- **code**: Intervention code (e.g., "iptp", "smc", etc.)
+- **type**: Unique identifier for the intervention within a code (e.g., "SP", "SP+AQ")
+- **places**: List of place IDs assigned to the intervention
+- **target_population_columns**: (Optional) List of population columns to use for quantification (e.g., ["pop_total"], ["pop_0_5", "pop_pw"])
+
+
+**Default target population columns by intervention:**
+
+**Default Target Population & Required Cost Units by Intervention:**
+
+| Intervention Code | Default Target Population Column(s) | Required Cost Unit(s)                |
+|-------------------|--------------------------------------|--------------------------------------|
+| itn_campaign      | pop_total                            | per ITN, per bale                    |
+| itn_routine       | pop_0_5, pop_pw                      | per ITN                              |
+| iptp              | pop_pw                               | per SP                               |
+| smc               | pop_0_5                              | per SPAQ pack 3-11 month olds,<br>per SPAQ pack 12-59 month olds |
+| pmc               | pop_0_1, pop_1_2                     | per SP                               |
+| vacc              | pop_vaccine_5_36_months              | per dose, per child                  |
+| default           | pop_total                            | Other                                |
+
+> **Note:**
+> - The `unit` column in your `cost_df` must match the required cost unit(s) for each intervention code above.
+> - Some interventions (like SMC and Vacc) require multiple units for different age groups or quantification types.
+
+> **Note:**
+> - The `unit` column in your `cost_df` must match the required cost unit(s) for each intervention code above.
+> - Some interventions (like SMC and Vacc) require multiple units for different age groups or quantification types.
+
+
+
+### 2. `settings` (Dictionary)
+Dictionary of cost and quantification assumptions. Defaults are provided in `DEFAULT_COST_ASSUMPTIONS` (see models.py).
+
+### 3. `cost_df` (DataFrame)
+DataFrame of unit costs, with columns such as:
+- code_intervention
+- type_intervention
+- cost_class
+- unit
+- ngn_cost
+- usd_cost
+- cost_year
+
+### 4. `population_df` (DataFrame)
+DataFrame with population data by place and year, with columns:
+- org_unit_id: Place ID
+- year: Year
+- Population columns: e.g., pop_total, pop_0_5, pop_pw, etc.
+
+If `target_population_columns` is not specified in the intervention, the default columns above are used.
+
+### 5. `local_currency` (str)
+The local currency symbol (e.g., "NGN", "EUR").
+
+### 6. `spatial_planning_unit` (str)
+The column name in `population_df` that identifies the spatial unit (e.g., "org_unit_id").
+
+### 7. `budget_currency` (str, optional)
+The currency for the budget output. Defaults to `local_currency`.
+
+### 8. `cost_overrides` (Optional[List[CostItems]])
+List of cost override items (see `CostItems` model).
+
+### 9. `unknown_intervention_handling` (str, optional)
+How to handle unknown interventions: "ignore", "handle", or "error".
 
 ## Development
 

--- a/snt_malaria_budgeting/core/budget_calculator.py
+++ b/snt_malaria_budgeting/core/budget_calculator.py
@@ -183,6 +183,9 @@ class BudgetCalculator:
     def _set_intervention_scen_data(self, budget_code, interventions, scen_df):
         code_column = f"code_{budget_code}"
         type_column = f"type_{budget_code}"
+        intervention_target_population_column = (
+            f"target_population_columns_{budget_code}"
+        )
 
         for intervention in interventions:
             intervention_places = intervention.places
@@ -192,6 +195,13 @@ class BudgetCalculator:
             mask = scen_df[self.spatial_planning_unit].isin(intervention_places)
             scen_df.loc[mask, code_column] = 1
             scen_df.loc[mask, type_column] = intervention_type
+            scen_df.loc[mask, intervention_target_population_column] = None
+
+            if intervention.target_population_columns:
+                scen_df.loc[mask, intervention_target_population_column] = pd.Series(
+                    [intervention.target_population_columns] * len(scen_df[mask]),
+                    index=scen_df[mask].index,
+                )
 
     def _get_scenario_dataframe(
         self,

--- a/snt_malaria_budgeting/core/quantification_functions/base_quantification.py
+++ b/snt_malaria_budgeting/core/quantification_functions/base_quantification.py
@@ -1,10 +1,6 @@
-from typing import Dict, List
+import itertools
 
 import pandas as pd
-
-# TODO We should get rid of the label pop column here.
-# Assumptions should have directly smth like pop_col: List[str] = ["pop_total"], and not this weird mapping we then need to do in the code.
-# Should also make sure this can be scoped per assignment, e.g., we might want to use different pop columns for the same intervention in different assignments.
 
 
 class BaseQuantification:
@@ -13,22 +9,46 @@ class BaseQuantification:
         code,
         spatial_unit="adm1",
         assumptions={},
-        label_pop_col="Total population",
         default_pop_col=["pop_total"],
         required_assumptions=[],
     ):
         self.code = code
         self.join_keys = [spatial_unit] + ["year"]
         self.assumptions = assumptions
-        self.pop_col = self._get_pop_column_(
-            label_pop_col, default_pop_col, assumptions=assumptions
-        )
+        self.default_pop_col = default_pop_col
         self.required_assumptions = required_assumptions
 
     def get_quantification(self, scen_data, target_population, all_quantifications):
         raise NotImplementedError("Subclasses must implement this method")
 
     def _get_base_df_(self, scen_data, target_population):
+        """
+        Retrieves and processes base dataframe by filtering scenario data and merging with target population.
+        This method filters the scenario data based on the intervention code, ensures the target population
+        columns are properly defined, validates that required columns exist in the target population dataframe,
+        and performs a merge operation.
+        Parameters
+        ----------
+        scen_data : pd.DataFrame
+            Scenario data dataframe containing a column named `code_{self.code}` with binary values (0 or 1).
+            Should also optionally contain a `target_population_columns` column with list values specifying
+            which columns from target_population to use for the merge.
+        target_population : pd.DataFrame
+            Target population dataframe containing columns specified in `self.join_keys` and any columns
+            referenced in the `target_population_columns` field from scen_data.
+        Returns
+        -------
+        pd.DataFrame
+            Merged dataframe containing rows from scen_data where `code_{self.code}` equals 1, combined with
+            corresponding rows from target_population based on join_keys. Returns an empty DataFrame if:
+            - The code column does not exist in scen_data
+            - No rows match the filter condition (code_{self.code} == 1)
+        Raises
+        ------
+        ValueError
+            If target_population does not contain all required columns (self.join_keys + target_population_columns).
+        """
+
         if f"code_{self.code}" not in scen_data.columns:
             return pd.DataFrame()
 
@@ -36,16 +56,41 @@ class BaseQuantification:
         if df.empty:
             return pd.DataFrame()
 
+        # Dataframe might or might not have a target_population_columns column that can vary depending on the intervention.
+        # We need to set that target_population_columns column using the predefine default_pop_col if it's not already in the dataframe.
+        if f"target_population_columns_{self.code}" not in df.columns:
+            df[f"target_population_columns_{self.code}"] = None
+
+        df[f"target_population_columns_{self.code}"] = df[
+            f"target_population_columns_{self.code}"
+        ].apply(lambda x: x if x is not None else self.default_pop_col)
+
+        # Get all columns from target_population_columns
+        target_population_columns = list(
+            dict.fromkeys(
+                itertools.chain.from_iterable(
+                    df[f"target_population_columns_{self.code}"]
+                )
+            )
+        )
+
         if not all(
-            col in target_population.columns for col in self.join_keys + self.pop_col
+            col in target_population.columns
+            for col in self.join_keys + list(target_population_columns)
         ):
             raise ValueError(
-                f"Target population DataFrame must contain columns: {self.join_keys + self.pop_col}"
+                f"Target population DataFrame must contain columns: {self.join_keys + list(target_population_columns)}"
             )
 
+        # Step 1: Filter target_population to only keep relevant columns for the merge
+        target_population_filtered = target_population[
+            self.join_keys + list(target_population_columns)
+        ]
+
+        # Step 2: Merge on the code column
         df = pd.merge(
             df,
-            target_population[self.join_keys + self.pop_col],
+            target_population_filtered,
             on=self.join_keys,
         )
 
@@ -62,26 +107,17 @@ class BaseQuantification:
                 f"Missing assumptions for {self.code}: {', '.join(missing_assumptions)}"
             )
 
-    # TODO: This part is weird, label can be: ITN Campaign: target population, etc ...
-    # So we try to get it from provided assumptions, which I guess look like something like {"ITN Campaign: target population": "Total population"},
-    # and then we have a mapping of what those labels mean in terms of pop columns, e.g., Total population => pop_total, Children under 5 => pop_0_5, etc ...
-    # But this doesn't allow to target other populations than hardcoded one from the parent class or the mapping.
-    # IMO we should just directly pass the pop columns we want to use as assumptions, and not have this mapping at all.
-    # This will be more flexible and less error prone.
-    # We can still have a default value if the assumption is not provided, but it should be the actual column name(s) in the pop DF, not some label that we then need to map to column names.
-    def _get_pop_column_(
-        self, label: str, default_col: List[str], assumptions: Dict[str, float]
-    ) -> List[str]:
-        pop_assumption = assumptions.get(label)
-        if not pop_assumption:
-            return default_col
-        mapping = {
-            "Total population": ["pop_total"],
-            "Children under 5": ["pop_0_5"],
-            "Children under 5 and pregnant women": ["pop_0_5", "pop_pw"],
-            "Children under 10": ["pop_0_5", "pop_5_10"],
-            "Children 0-1": ["pop_0_1"],
-            "Children 1-2": ["pop_1_2"],
-            "Pregnant women": ["pop_pw"],
-        }
-        return mapping.get(str(pop_assumption), default_col)
+    def _get_sum_target_population_(self, base_df):
+        return base_df.apply(
+            lambda row: sum(
+                row[pop_col]
+                for pop_col in row[f"target_population_columns_{self.code}"]
+            ),
+            axis=1,
+        )
+
+    def _get_target_population_df_(self, base_df):
+        return base_df.apply(
+            lambda row: row[row[f"target_population_columns_{self.code}"]],
+            axis=1,
+        )

--- a/snt_malaria_budgeting/core/quantification_functions/base_quantification.py
+++ b/snt_malaria_budgeting/core/quantification_functions/base_quantification.py
@@ -18,7 +18,16 @@ class BaseQuantification:
         self.default_pop_col = default_pop_col
         self.required_assumptions = required_assumptions
 
-    def get_quantification(self, scen_data, target_population, all_quantifications):
+    def get_quantification(self, scen_data, target_population):
+        df = self._get_base_df_(scen_data, target_population)
+        if df.empty:
+            return pd.DataFrame()
+
+        self._validate_df_(df)
+
+        return self._get_quantification_(df)
+
+    def _get_quantification_(self, df):
         raise NotImplementedError("Subclasses must implement this method")
 
     def _get_base_df_(self, scen_data, target_population):
@@ -95,6 +104,9 @@ class BaseQuantification:
         )
 
         return df
+
+    def _validate_df_(self, df):
+        self._validate_assumptions_()
 
     def _validate_assumptions_(self):
         missing_assumptions = [

--- a/snt_malaria_budgeting/core/quantification_functions/default_quantification.py
+++ b/snt_malaria_budgeting/core/quantification_functions/default_quantification.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from .base_quantification import BaseQuantification
 
 

--- a/snt_malaria_budgeting/core/quantification_functions/default_quantification.py
+++ b/snt_malaria_budgeting/core/quantification_functions/default_quantification.py
@@ -12,7 +12,7 @@ class DefaultQuantification(BaseQuantification):
             default_pop_col=["pop_total"],
         )
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate quantification for an intervention based on scenario data and target population.
 
@@ -20,8 +20,7 @@ class DefaultQuantification(BaseQuantification):
         with calculated quantities and metadata for the intervention.
 
         Args:
-            scen_data: Scenario data containing information needed to build the base DataFrame.
-            target_population: Target population parameters for quantification calculation.
+            df: DataFrame containing the filtered and merged scenario and target population data.
 
         Returns:
             pd.DataFrame: A DataFrame containing quantification results with columns:
@@ -37,10 +36,6 @@ class DefaultQuantification(BaseQuantification):
               falling back to "default_coverage" (default: 0.8) if not found.
             - The unit field defaults to "none" and is used internally for cost class determination.
         """
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
         coverage = self.assumptions.get(
             f"{self.code}_coverage", self.assumptions.get("default_coverage", 1)
         )

--- a/snt_malaria_budgeting/core/quantification_functions/default_quantification.py
+++ b/snt_malaria_budgeting/core/quantification_functions/default_quantification.py
@@ -45,9 +45,11 @@ class DefaultQuantification(BaseQuantification):
             f"{self.code}_coverage", self.assumptions.get("default_coverage", 1)
         )
 
+        target_pop_sum = self._get_sum_target_population_(df)
+
         return df.assign(
-            quantity=(df[self.pop_col[0]] * coverage),
-            target_pop=df[self.pop_col[0]],
+            quantity=target_pop_sum * coverage,
+            target_pop=target_pop_sum,
             code_intervention=self.code,
             type_intervention=df[f"type_{self.code}"],
             unit="Other",  # This is a tricky one, it is used to know which cost class we should use but for default, we don't have any

--- a/snt_malaria_budgeting/core/quantification_functions/iptp.py
+++ b/snt_malaria_budgeting/core/quantification_functions/iptp.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from .base_quantification import BaseQuantification
 
 

--- a/snt_malaria_budgeting/core/quantification_functions/iptp.py
+++ b/snt_malaria_budgeting/core/quantification_functions/iptp.py
@@ -9,7 +9,6 @@ class IPTPQuantification(BaseQuantification):
             "iptp",
             spatial_unit,
             assumptions=assumptions,
-            label_pop_col="IPTp: target population",
             default_pop_col=["pop_pw"],
             required_assumptions=[
                 "iptp_anc_coverage",
@@ -45,13 +44,15 @@ class IPTPQuantification(BaseQuantification):
 
         self._validate_assumptions_()
 
+        sum_target_pop = self._get_sum_target_population_(df)
+
         return df.assign(
             quantity=(
-                (df[self.pop_col[0]] * self.assumptions[f"{self.code}_anc_coverage"])
+                (sum_target_pop * self.assumptions[f"{self.code}_anc_coverage"])
                 * self.assumptions[f"{self.code}_doses_per_pw"]
             )
             * self.assumptions[f"{self.code}_buffer_mult"],
-            target_pop=df[self.pop_col[0]],
+            target_pop=sum_target_pop,
             code_intervention=self.code,
             type_intervention=df[f"type_{self.code}"],
             unit="per SP",

--- a/snt_malaria_budgeting/core/quantification_functions/iptp.py
+++ b/snt_malaria_budgeting/core/quantification_functions/iptp.py
@@ -17,7 +17,7 @@ class IPTPQuantification(BaseQuantification):
             ],
         )
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate the quantification of IPTp (Intermittent Preventive Treatment in pregnancy) doses.
 
@@ -25,8 +25,7 @@ class IPTPQuantification(BaseQuantification):
         doses per pregnant women, and buffer multiplier assumptions.
 
         Args:
-            scen_data: Scenario data containing relevant assumptions and parameters.
-            target_population: Target population class or identifier for which to calculate quantification.
+            df: DataFrame containing the filtered and merged scenario and target population data.
 
         Returns:
             pd.DataFrame: DataFrame with calculated quantification including columns:
@@ -38,11 +37,6 @@ class IPTPQuantification(BaseQuantification):
 
             Returns an empty DataFrame if base data is empty.
         """
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
-        self._validate_assumptions_()
 
         sum_target_pop = self._get_sum_target_population_(df)
 

--- a/snt_malaria_budgeting/core/quantification_functions/itn_campaign.py
+++ b/snt_malaria_budgeting/core/quantification_functions/itn_campaign.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from .base_quantification import BaseQuantification
 
 

--- a/snt_malaria_budgeting/core/quantification_functions/itn_campaign.py
+++ b/snt_malaria_budgeting/core/quantification_functions/itn_campaign.py
@@ -17,7 +17,7 @@ class ItnCampaignQuantification(BaseQuantification):
             ],
         )
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate ITN (Insecticide-Treated Net) quantification based on scenario data and target population.
 
@@ -25,8 +25,7 @@ class ItnCampaignQuantification(BaseQuantification):
         applying coverage rates, divisor factors, and buffer multipliers from assumptions.
 
         Args:
-            scen_data: Scenario data containing configuration and parameters for the calculation.
-            target_population: Population data used to determine the baseline for quantification.
+            df: DataFrame containing the filtered and merged scenario and target population data.
 
         Returns:
             pd.DataFrame: A long-format DataFrame containing quantification data with columns:
@@ -41,12 +40,6 @@ class ItnCampaignQuantification(BaseQuantification):
             - Converts net quantities to bale quantities using the bale_size assumption
             - Uses assumption keys: `{code}_coverage`, `{code}_divisor`, `{code}_buffer_mult`, `{code}_bale_size`
         """
-
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
-        self._validate_assumptions_()
 
         target_pop_raw = self._get_sum_target_population_(df)
 

--- a/snt_malaria_budgeting/core/quantification_functions/itn_campaign.py
+++ b/snt_malaria_budgeting/core/quantification_functions/itn_campaign.py
@@ -8,7 +8,6 @@ class ItnCampaignQuantification(BaseQuantification):
             "itn_campaign",
             spatial_unit,
             assumptions=assumptions,
-            label_pop_col="ITN Campaign: target population",
             default_pop_col=["pop_total"],
             required_assumptions=[
                 "itn_campaign_coverage",
@@ -49,7 +48,7 @@ class ItnCampaignQuantification(BaseQuantification):
 
         self._validate_assumptions_()
 
-        target_pop_raw = df[self.pop_col].sum(axis=1)
+        target_pop_raw = self._get_sum_target_population_(df)
 
         df = df.assign(
             quant_nets=(

--- a/snt_malaria_budgeting/core/quantification_functions/itn_routine.py
+++ b/snt_malaria_budgeting/core/quantification_functions/itn_routine.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from .base_quantification import BaseQuantification
 
 

--- a/snt_malaria_budgeting/core/quantification_functions/itn_routine.py
+++ b/snt_malaria_budgeting/core/quantification_functions/itn_routine.py
@@ -8,7 +8,6 @@ class ItnRoutineQuantification(BaseQuantification):
             "itn_routine",
             spatial_unit,
             assumptions=assumptions,
-            label_pop_col="ITN Routine: target population",
             default_pop_col=["pop_0_5", "pop_pw"],
             required_assumptions=[
                 "itn_routine_coverage",
@@ -58,11 +57,12 @@ class ItnRoutineQuantification(BaseQuantification):
 
         self._validate_assumptions_()
 
-        df["target_pop"] = df[self.pop_col].sum(axis=1)
+        target_pop_raw = self._get_sum_target_population_(df)
         return df.assign(
-            quantity=(df["target_pop"] * self.assumptions[f"{self.code}_coverage"])
+            quantity=(target_pop_raw * self.assumptions[f"{self.code}_coverage"])
             * self.assumptions[f"{self.code}_buffer_mult"],
             code_intervention=self.code,
             type_intervention=df[f"type_{self.code}"],
             unit="per ITN",
+            target_pop=target_pop_raw,
         )

--- a/snt_malaria_budgeting/core/quantification_functions/itn_routine.py
+++ b/snt_malaria_budgeting/core/quantification_functions/itn_routine.py
@@ -15,7 +15,7 @@ class ItnRoutineQuantification(BaseQuantification):
             ],
         )
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate the quantification of ITN (Insecticide-Treated Net) interventions.
         This method computes the number of ITNs needed based on target population,
@@ -51,11 +51,6 @@ class ItnRoutineQuantification(BaseQuantification):
 
         # --- Quantification (Partner Guide: 4.3) ---
         # Get population of interest (e.g., children under 5 or pregnant
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
-        self._validate_assumptions_()
 
         target_pop_raw = self._get_sum_target_population_(df)
         return df.assign(

--- a/snt_malaria_budgeting/core/quantification_functions/pmc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/pmc.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from .base_quantification import BaseQuantification
 
 

--- a/snt_malaria_budgeting/core/quantification_functions/pmc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/pmc.py
@@ -9,7 +9,6 @@ class PMCQuantification(BaseQuantification):
             "pmc",
             spatial_unit,
             assumptions=assumptions,
-            label_pop_col="PMC: target population",
             default_pop_col=["pop_0_1", "pop_1_2"],
             required_assumptions=[
                 "pmc_coverage",
@@ -18,6 +17,17 @@ class PMCQuantification(BaseQuantification):
                 "pmc_buffer_mult",
             ],
         )
+
+    def _validate_df_(self, df):
+        if (
+            not df[f"target_population_columns_{self.code}"]
+            .apply(lambda x: len(x) == 2)
+            .all()
+        ):
+            raise ValueError(
+                f"target_population_columns_{self.code} must contain exactly 2 items"
+            )
+        return super()._validate_assumptions_()
 
     def get_quantification(self, scen_data, target_population):
         """
@@ -42,14 +52,17 @@ class PMCQuantification(BaseQuantification):
             - Calculations include coverage, touchpoints, tablet_factor, and buffer multiplier assumptions
         """
 
+        # TODO, I think this could be moved to based class
         df = self._get_base_df_(scen_data, target_population)
         if df.empty:
             return pd.DataFrame()
 
-        self._validate_assumptions_()
+        self._validate_df_(df)
 
-        pop_0_1 = df[self.pop_col[0]]
-        pop_1_2 = df[self.pop_col[1]]
+        pop_df = self._get_target_population_df_(df)
+
+        pop_0_1 = pop_df.iloc[:, 0]
+        pop_1_2 = pop_df.iloc[:, 1]
 
         sp_0_1 = (
             pop_0_1

--- a/snt_malaria_budgeting/core/quantification_functions/pmc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/pmc.py
@@ -29,15 +29,14 @@ class PMCQuantification(BaseQuantification):
             )
         return super()._validate_assumptions_()
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate the quantification of preventive medicine doses for malaria-affected populations.
         This method computes the required quantity of seasonal preventive chemotherapy (SP) tablets
         based on population segments (children 0-1 years and 1-2 years), coverage rates, touchpoints,
         and dosage factors.
         Args:
-            scen_data: Dictionary containing scenario-specific data for quantification calculations.
-            target_population: The target population data used to filter and process the base dataframe.
+            df: DataFrame containing the filtered and merged scenario and target population data.
         Returns:
             pd.DataFrame: A dataframe with the following columns:
                 - quantity: Total number of SP tablets required (sum of sp_0_1 and sp_1_2)
@@ -51,13 +50,6 @@ class PMCQuantification(BaseQuantification):
             - Children 1-2 years receive 2 doses per touchpoint (sp_1_2)
             - Calculations include coverage, touchpoints, tablet_factor, and buffer multiplier assumptions
         """
-
-        # TODO, I think this could be moved to based class
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
-        self._validate_df_(df)
 
         pop_df = self._get_target_population_df_(df)
 

--- a/snt_malaria_budgeting/core/quantification_functions/smc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/smc.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from .base_quantification import BaseQuantification
 
 

--- a/snt_malaria_budgeting/core/quantification_functions/smc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/smc.py
@@ -19,7 +19,7 @@ class SMCQuantification(BaseQuantification):
             ],
         )
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate SMC (Seasonal Malaria Chemoprevention) quantification requirements.
         This method computes the required quantities of SPAQ (Sulfadoxine-Pyrimethamine + Amodiaquine)
@@ -27,9 +27,11 @@ class SMCQuantification(BaseQuantification):
         rounds of treatment.
         Parameters
         ----------
-        scen_data : dict or DataFrame
-            Scenario data containing population and intervention-related information.
-        target_population : int or str
+        df : pd.DataFrame
+            DataFrame containing the filtered and merged scenario and target population data.
+        Returns
+        -------
+        pd.DataFrame
             The target population identifier or value used to filter/process scenario data.
         Returns
         -------
@@ -55,12 +57,6 @@ class SMCQuantification(BaseQuantification):
         - Number of monthly rounds
         - Buffer multiplier for safety stock
         """
-
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
-        self._validate_assumptions_()
 
         target_pop_raw = self._get_sum_target_population_(df)
 

--- a/snt_malaria_budgeting/core/quantification_functions/smc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/smc.py
@@ -9,7 +9,6 @@ class SMCQuantification(BaseQuantification):
             "smc",
             spatial_unit,
             assumptions=assumptions,
-            label_pop_col="SMC: target population",
             default_pop_col=["pop_0_5"],
             required_assumptions=[
                 "smc_coverage",
@@ -63,21 +62,23 @@ class SMCQuantification(BaseQuantification):
 
         self._validate_assumptions_()
 
+        target_pop_raw = self._get_sum_target_population_(df)
+
         df = df.assign(
             quant_smc_3_11_months=(
-                (df[self.pop_col[0]] * self.assumptions[f"{self.code}_pop_prop_3_11"])
+                (target_pop_raw * self.assumptions[f"{self.code}_pop_prop_3_11"])
                 * self.assumptions[f"{self.code}_coverage"]
             )
             * self.assumptions[f"{self.code}_monthly_rounds"]
             * self.assumptions[f"{self.code}_buffer_mult"],
             quant_smc_12_59_months=(
-                (df[self.pop_col[0]] * self.assumptions[f"{self.code}_pop_prop_12_59"])
+                (target_pop_raw * self.assumptions[f"{self.code}_pop_prop_12_59"])
                 * self.assumptions[f"{self.code}_coverage"]
             )
             * self.assumptions[f"{self.code}_monthly_rounds"]
             * self.assumptions[f"{self.code}_buffer_mult"],
             target_pop=(
-                df[self.pop_col[0]]
+                target_pop_raw
                 * (
                     self.assumptions[f"{self.code}_pop_prop_3_11"]
                     + self.assumptions[f"{self.code}_pop_prop_12_59"]

--- a/snt_malaria_budgeting/core/quantification_functions/vacc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/vacc.py
@@ -19,14 +19,13 @@ class VaccQuantification(BaseQuantification):
             ],
         )
 
-    def get_quantification(self, scen_data, target_population):
+    def _get_quantification_(self, df):
         """
         Calculate quantification metrics for vaccination interventions.
         This method computes the required doses and target child population for a vaccination
         intervention based on scenario data, coverage assumptions, and dosing parameters.
         Args:
-            scen_data: Scenario data containing relevant parameters and context for the calculation.
-            target_population: The target population segment for which to calculate quantification.
+            df: DataFrame containing the filtered and merged scenario and target population data.
         Returns:
             pd.DataFrame: A long-format DataFrame containing quantification results with the following columns:
                 - All columns from the base dataframe (except those starting with "quant_")
@@ -42,12 +41,6 @@ class VaccQuantification(BaseQuantification):
             - Converts wide format (quant_doses, quant_child) to long format for easier analysis
             - Buffer multiplier accounts for waste and contingency in dose calculations
         """
-
-        df = self._get_base_df_(scen_data, target_population)
-        if df.empty:
-            return pd.DataFrame()
-
-        self._validate_assumptions_()
 
         target_pop_raw = self._get_sum_target_population_(df)
 

--- a/snt_malaria_budgeting/core/quantification_functions/vacc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/vacc.py
@@ -11,7 +11,6 @@ class VaccQuantification(BaseQuantification):
             "vacc",
             spatial_unit,
             assumptions=assumptions,
-            label_pop_col="Vaccine: target population",
             default_pop_col=["pop_vaccine_5_36_months"],
             required_assumptions=[
                 "vacc_coverage",
@@ -50,12 +49,14 @@ class VaccQuantification(BaseQuantification):
 
         self._validate_assumptions_()
 
+        target_pop_raw = self._get_sum_target_population_(df)
+
         df = df.assign(
-            quant_doses=df[self.pop_col[0]]
+            quant_doses=target_pop_raw
             * self.assumptions[f"{self.code}_coverage"]
             * self.assumptions[f"{self.code}_doses_per_child"]
             * self.assumptions[f"{self.code}_buffer_mult"],
-            quant_child=df[self.pop_col[0]] * self.assumptions[f"{self.code}_coverage"],
+            quant_child=target_pop_raw * self.assumptions[f"{self.code}_coverage"],
         ).assign(
             target_pop=lambda x: x.quant_child,
             code_intervention=self.code,

--- a/snt_malaria_budgeting/core/quantification_functions/vacc.py
+++ b/snt_malaria_budgeting/core/quantification_functions/vacc.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from snt_malaria_budgeting.core.quantification_functions.base_quantification import (
     BaseQuantification,
 )

--- a/snt_malaria_budgeting/models.py
+++ b/snt_malaria_budgeting/models.py
@@ -44,6 +44,7 @@ class InterventionDetailModel(BaseModel):
     type: str
     code: str
     places: List[Union[str, int]]
+    target_population_columns: List[str] = Field(default_factory=list)
 
 
 class CostItems(BaseModel):

--- a/tests/core/quantification_functions/test_default_quantification.py
+++ b/tests/core/quantification_functions/test_default_quantification.py
@@ -34,6 +34,8 @@ class TestDefaultQuantification(unittest.TestCase):
                 "adm2": [admin2],
                 "year": [year],
                 "pop_total": [342988.7383],
+                "pop_total_custom": [342988.7383],
+                "pop_total_custom_2": [342988.7383],
             }
         )
 
@@ -82,6 +84,72 @@ class TestDefaultQuantification(unittest.TestCase):
         self.assertAlmostEqual(result["quantity"].iloc[0], expected_quantity)
         self.assertAlmostEqual(
             result["target_pop"].iloc[0], self.mock_population_data["pop_total"][0]
+        )
+        self.assertEqual(result["code_intervention"].iloc[0], "something")
+        self.assertEqual(result["type_intervention"].iloc[0], "SMTH")
+        self.assertEqual(result["unit"].iloc[0], "Other")
+
+    def test_default_quantification_override_pop_column(self):
+        """Test that DefaultQuantification returns expected results for a known code with overridden population column."""
+
+        quant = DefaultQuantification(
+            code="something",
+            spatial_unit="adm2",
+            assumptions={"something_coverage": 0.5},
+        )
+        scen_data = self.scen_data.copy()
+        scen_data[f"target_population_columns_{quant.code}"] = [["pop_total_custom"]]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity = self.mock_population_data["pop_total_custom"][0] * 0.5
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        self.assertAlmostEqual(result["quantity"].iloc[0], expected_quantity)
+        self.assertAlmostEqual(
+            result["target_pop"].iloc[0],
+            self.mock_population_data["pop_total_custom"][0],
+        )
+        self.assertEqual(result["code_intervention"].iloc[0], "something")
+        self.assertEqual(result["type_intervention"].iloc[0], "SMTH")
+        self.assertEqual(result["unit"].iloc[0], "Other")
+
+    def test_default_quantification_override_pop_column_many(self):
+        """Test that DefaultQuantification returns expected results for a known code with overridden population column."""
+
+        quant = DefaultQuantification(
+            code="something",
+            spatial_unit="adm2",
+            assumptions={"something_coverage": 0.5},
+        )
+        scen_data = self.scen_data.copy()
+        scen_data[f"target_population_columns_{quant.code}"] = [
+            ["pop_total_custom", "pop_total_custom_2"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity = (
+            self.mock_population_data["pop_total_custom"][0]
+            + self.mock_population_data["pop_total_custom_2"][0]
+        ) * 0.5
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        self.assertAlmostEqual(result["quantity"].iloc[0], expected_quantity)
+        self.assertAlmostEqual(
+            result["target_pop"].iloc[0],
+            self.mock_population_data["pop_total_custom"][0]
+            + self.mock_population_data["pop_total_custom_2"][0],
         )
         self.assertEqual(result["code_intervention"].iloc[0], "something")
         self.assertEqual(result["type_intervention"].iloc[0], "SMTH")

--- a/tests/core/quantification_functions/test_iptp_quantification.py
+++ b/tests/core/quantification_functions/test_iptp_quantification.py
@@ -32,6 +32,8 @@ class TestIPTPQuantification(unittest.TestCase):
                 "adm2": [admin2],
                 "year": [year],
                 "pop_pw": [342988.7383],
+                "pop_pw_custom": [32988.7383],
+                "pop_pw_custom_2": [32988.7383],
             }
         )
 
@@ -83,6 +85,84 @@ class TestIPTPQuantification(unittest.TestCase):
         self.assertAlmostEqual(result["quantity"].iloc[0], expected_quantity)
         self.assertAlmostEqual(
             result["target_pop"].iloc[0], self.mock_population_data["pop_pw"][0]
+        )
+        self.assertEqual(result["code_intervention"].iloc[0], "iptp")
+        self.assertEqual(result["type_intervention"].iloc[0], "IPTP")
+        self.assertEqual(result["unit"].iloc[0], "per SP")
+
+    def test_iptp_quantification_custom_population_column(self):
+        """Test that IPTPQuantification returns expected results when using a custom population column."""
+
+        quant = IPTPQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "iptp_anc_coverage": 0.5,
+                "iptp_doses_per_pw": 1.5,
+                "iptp_buffer_mult": 1.1,
+            },
+        )
+        scen_data = self.scen_data.assign(
+            target_population_columns_iptp=[["pop_pw_custom"]]
+        )
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity = (
+            self.mock_population_data["pop_pw_custom"][0] * 0.5 * 1.5 * 1.1
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        self.assertAlmostEqual(result["quantity"].iloc[0], expected_quantity)
+        self.assertAlmostEqual(
+            result["target_pop"].iloc[0], self.mock_population_data["pop_pw_custom"][0]
+        )
+        self.assertEqual(result["code_intervention"].iloc[0], "iptp")
+        self.assertEqual(result["type_intervention"].iloc[0], "IPTP")
+        self.assertEqual(result["unit"].iloc[0], "per SP")
+
+    def test_iptp_quantification_multiple_custom_population_columns(self):
+        """Test that IPTPQuantification returns expected results when using multiple custom population columns."""
+
+        quant = IPTPQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "iptp_anc_coverage": 0.5,
+                "iptp_doses_per_pw": 1.5,
+                "iptp_buffer_mult": 1.1,
+            },
+        )
+        scen_data = self.scen_data.assign(
+            target_population_columns_iptp=[["pop_pw_custom", "pop_pw_custom_2"]]
+        )
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity = (
+            (
+                self.mock_population_data["pop_pw_custom"][0]
+                + self.mock_population_data["pop_pw_custom_2"][0]
+            )
+            * 0.5
+            * 1.5
+            * 1.1
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        self.assertAlmostEqual(result["quantity"].iloc[0], expected_quantity)
+        self.assertAlmostEqual(
+            result["target_pop"].iloc[0],
+            self.mock_population_data["pop_pw_custom"][0]
+            + self.mock_population_data["pop_pw_custom_2"][0],
         )
         self.assertEqual(result["code_intervention"].iloc[0], "iptp")
         self.assertEqual(result["type_intervention"].iloc[0], "IPTP")

--- a/tests/core/quantification_functions/test_itn_campaign_quantification.py
+++ b/tests/core/quantification_functions/test_itn_campaign_quantification.py
@@ -36,6 +36,8 @@ class TestItnCampaignQuantification(unittest.TestCase):
                 "adm2": [admin2],
                 "year": [year],
                 "pop_total": [342988.7383],
+                "pop_custom": [32988.7383],
+                "pop_custom_2": [30988.7383],
             }
         )
 
@@ -95,6 +97,106 @@ class TestItnCampaignQuantification(unittest.TestCase):
         self.assertAlmostEqual(bale_result["quantity"], expected_bale_quantity)
         self.assertAlmostEqual(
             bale_result["target_pop"], self.mock_population_data["pop_total"][0] * 0.5
+        )
+
+    def test_itn_campaign_quantification_custom_pop_columns(self):
+        """Test that ItnCampaignQuantification returns expected results for a known code with overridden population column."""
+
+        quant = ItnCampaignQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "itn_campaign_coverage": 0.5,
+                "itn_campaign_divisor": 1.5,
+                "itn_campaign_buffer_mult": 1.1,
+                "itn_campaign_bale_size": 10,
+            },
+        )
+        scen_data = self.scen_data.assign(
+            target_population_columns_itn_campaign=[["pop_custom"]]
+        )
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_net_quantity = (
+            self.mock_population_data["pop_custom"][0] * 0.5 * 1.1 / 1.5
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        net_result = result[result["unit"] == "per ITN"].iloc[0]
+
+        self.assertAlmostEqual(net_result["quantity"], expected_net_quantity)
+        self.assertAlmostEqual(
+            net_result["target_pop"], self.mock_population_data["pop_custom"][0] * 0.5
+        )
+
+        expected_bale_quantity = expected_net_quantity / 10
+        bale_result = result[result["unit"] == "per bale"].iloc[0]
+        self.assertAlmostEqual(bale_result["quantity"], expected_bale_quantity)
+        self.assertAlmostEqual(
+            bale_result["target_pop"], self.mock_population_data["pop_custom"][0] * 0.5
+        )
+
+    def test_itn_campaign_quantification_multiple_custom_pop_columns(self):
+        """Test that ItnCampaignQuantification returns expected results for a known code with overridden population column."""
+
+        quant = ItnCampaignQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "itn_campaign_coverage": 0.5,
+                "itn_campaign_divisor": 1.5,
+                "itn_campaign_buffer_mult": 1.1,
+                "itn_campaign_bale_size": 10,
+            },
+        )
+        scen_data = self.scen_data.assign(
+            target_population_columns_itn_campaign=[["pop_custom", "pop_custom_2"]]
+        )
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_net_quantity = (
+            (
+                self.mock_population_data["pop_custom"][0]
+                + self.mock_population_data["pop_custom_2"][0]
+            )
+            * 0.5
+            * 1.1
+            / 1.5
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        net_result = result[result["unit"] == "per ITN"].iloc[0]
+
+        self.assertAlmostEqual(net_result["quantity"], expected_net_quantity)
+        self.assertAlmostEqual(
+            net_result["target_pop"],
+            (
+                self.mock_population_data["pop_custom"][0]
+                + self.mock_population_data["pop_custom_2"][0]
+            )
+            * 0.5,
+        )
+
+        expected_bale_quantity = expected_net_quantity / 10
+        bale_result = result[result["unit"] == "per bale"].iloc[0]
+        self.assertAlmostEqual(bale_result["quantity"], expected_bale_quantity)
+        self.assertAlmostEqual(
+            bale_result["target_pop"],
+            (
+                self.mock_population_data["pop_custom"][0]
+                + self.mock_population_data["pop_custom_2"][0]
+            )
+            * 0.5,
         )
 
     def test_itn_campaign_quantification_empty_base(self):

--- a/tests/core/quantification_functions/test_itn_routine_quantification.py
+++ b/tests/core/quantification_functions/test_itn_routine_quantification.py
@@ -37,6 +37,10 @@ class TestItnRoutineQuantification(unittest.TestCase):
                 "year": [year],
                 "pop_0_5": [342988.7383],
                 "pop_pw": [20134.897],
+                "pop_0_5_custom": [32988.7383],
+                "pop_pw_custom": [2134.897],
+                "pop_0_5_custom_2": [30988.7383],
+                "pop_pw_custom_2": [2034.897],
             }
         )
 
@@ -50,7 +54,7 @@ class TestItnRoutineQuantification(unittest.TestCase):
                 ],
                 "unit": ["per ITN"],
                 "cost_class": ["Commodity"],
-                "cost_year_for_analysis": 2025,
+                "cost_year_for_analysis": year,
                 "usd_cost": [1.0],
                 "local_currency_cost": [584.0],
                 "cost_name": ["test"],
@@ -93,6 +97,96 @@ class TestItnRoutineQuantification(unittest.TestCase):
             (
                 self.mock_population_data["pop_0_5"][0]
                 + self.mock_population_data["pop_pw"][0]
+            ),
+        )
+
+    def test_itn_routine_quantification_custom_target_population(self):
+        """Test that ItnRoutineQuantification returns expected results for a known code with custom target population."""
+
+        quant = ItnRoutineQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "itn_routine_coverage": 0.5,
+                "itn_routine_buffer_mult": 1.1,
+            },
+        )
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_itn_routine"] = [
+            ["pop_0_5_custom", "pop_pw_custom"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity = (
+            (
+                self.mock_population_data["pop_0_5_custom"][0]
+                + self.mock_population_data["pop_pw_custom"][0]
+            )
+            * 0.5
+            * 1.1
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        net_result = result[result["unit"] == "per ITN"].iloc[0]
+
+        self.assertAlmostEqual(net_result["quantity"], expected_quantity)
+        self.assertAlmostEqual(
+            net_result["target_pop"],
+            (
+                self.mock_population_data["pop_0_5_custom"][0]
+                + self.mock_population_data["pop_pw_custom"][0]
+            ),
+        )
+
+    def test_itn_routine_quantification_multiple_custom_target_population(self):
+        """Test that ItnRoutineQuantification returns expected results for a known code with multiple custom target populations."""
+
+        quant = ItnRoutineQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "itn_routine_coverage": 0.5,
+                "itn_routine_buffer_mult": 1.1,
+            },
+        )
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_itn_routine"] = [
+            ["pop_0_5_custom", "pop_pw_custom", "pop_0_5_custom_2", "pop_pw_custom_2"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity = (
+            (
+                self.mock_population_data["pop_0_5_custom"][0]
+                + self.mock_population_data["pop_pw_custom"][0]
+                + self.mock_population_data["pop_0_5_custom_2"][0]
+                + self.mock_population_data["pop_pw_custom_2"][0]
+            )
+            * 0.5
+            * 1.1
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        net_result = result[result["unit"] == "per ITN"].iloc[0]
+
+        self.assertAlmostEqual(net_result["quantity"], expected_quantity)
+        self.assertAlmostEqual(
+            net_result["target_pop"],
+            (
+                self.mock_population_data["pop_0_5_custom"][0]
+                + self.mock_population_data["pop_pw_custom"][0]
+                + self.mock_population_data["pop_0_5_custom_2"][0]
+                + self.mock_population_data["pop_pw_custom_2"][0]
             ),
         )
 

--- a/tests/core/quantification_functions/test_pmc_quantification.py
+++ b/tests/core/quantification_functions/test_pmc_quantification.py
@@ -134,11 +134,35 @@ class TestPMCQuantification(unittest.TestCase):
             + self.mock_population_data["pop_1_2_custom"][0] * 0.5,
         )
 
-    def test_pmc_quantitification_invalid_target_population_columns(self):
+    def test_pmc_quantitification_to_few_target_population_columns(self):
         """Test that PMCQuantification raises an error when target_population_columns does not contain exactly 2 items."""
 
         scen_data_invalid_pop_cols = self.scen_data.copy()
         scen_data_invalid_pop_cols["target_population_columns_pmc"] = [["pop_0_1"]]
+
+        quant = PMCQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "pmc_coverage": 0.5,
+                "pmc_touchpoints": 1.5,
+                "pmc_tablet_factor": 1.1,
+                "pmc_buffer_mult": 1.1,
+            },
+        )
+        with self.assertRaisesRegex(
+            ValueError, r"target_population_columns_pmc must contain exactly 2 items"
+        ):
+            quant.get_quantification(
+                scen_data_invalid_pop_cols, self.mock_population_data
+            )
+
+    def test_pmc_quantitification_too_many_target_population_columns(self):
+        """Test that PMCQuantification raises an error when target_population_columns contains more than 2 items."""
+
+        scen_data_invalid_pop_cols = self.scen_data.copy()
+        scen_data_invalid_pop_cols["target_population_columns_pmc"] = [
+            ["pop_0_1", "pop_1_2", "pop_0_1_custom"]
+        ]
 
         quant = PMCQuantification(
             spatial_unit="adm2",

--- a/tests/core/quantification_functions/test_pmc_quantification.py
+++ b/tests/core/quantification_functions/test_pmc_quantification.py
@@ -35,6 +35,8 @@ class TestPMCQuantification(unittest.TestCase):
                 "year": [year],
                 "pop_0_1": [342988.7383],
                 "pop_1_2": [20134.897],
+                "pop_0_1_custom": [32988.7383],
+                "pop_1_2_custom": [2134.897],
             }
         )
 
@@ -90,6 +92,69 @@ class TestPMCQuantification(unittest.TestCase):
             self.mock_population_data["pop_0_1"][0] * 0.5
             + self.mock_population_data["pop_1_2"][0] * 0.5,
         )
+
+    def test_pmc_quantification_custom_target_population(self):
+        """Test that PMCQuantification returns expected results for a known code with custom target population columns."""
+
+        quant = PMCQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "pmc_coverage": 0.5,
+                "pmc_touchpoints": 1.5,
+                "pmc_tablet_factor": 1.1,
+                "pmc_buffer_mult": 1.1,
+            },
+        )
+
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_pmc"] = [
+            ["pop_0_1_custom", "pop_1_2_custom"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        assumption_ratio = 0.5 * 1.5 * 1.1 * 1.1
+        expected_quantity = (
+            self.mock_population_data["pop_0_1_custom"][0] * assumption_ratio
+            + self.mock_population_data["pop_1_2_custom"][0] * assumption_ratio * 2
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        net_result = result[result["unit"] == "per SP"].iloc[0]
+
+        self.assertAlmostEqual(net_result["quantity"], expected_quantity)
+        self.assertAlmostEqual(
+            net_result["target_pop"],
+            self.mock_population_data["pop_0_1_custom"][0] * 0.5
+            + self.mock_population_data["pop_1_2_custom"][0] * 0.5,
+        )
+
+    def test_pmc_quantitification_invalid_target_population_columns(self):
+        """Test that PMCQuantification raises an error when target_population_columns does not contain exactly 2 items."""
+
+        scen_data_invalid_pop_cols = self.scen_data.copy()
+        scen_data_invalid_pop_cols["target_population_columns_pmc"] = [["pop_0_1"]]
+
+        quant = PMCQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "pmc_coverage": 0.5,
+                "pmc_touchpoints": 1.5,
+                "pmc_tablet_factor": 1.1,
+                "pmc_buffer_mult": 1.1,
+            },
+        )
+        with self.assertRaisesRegex(
+            ValueError, r"target_population_columns_pmc must contain exactly 2 items"
+        ):
+            quant.get_quantification(
+                scen_data_invalid_pop_cols, self.mock_population_data
+            )
 
     def test_pmc_quantification_empty_base(self):
         """Test that PMCQuantification returns an empty DataFrame when base data is empty."""

--- a/tests/core/quantification_functions/test_smc_quantification.py
+++ b/tests/core/quantification_functions/test_smc_quantification.py
@@ -34,6 +34,8 @@ class TestSMCQuantification(unittest.TestCase):
                 "adm2": [admin2],
                 "year": [year],
                 "pop_0_5": [342988.7383],
+                "pop_0_5_custom": [32988.7383],
+                "pop_0_5_custom_2": [30988.7383],
             }
         )
 
@@ -71,6 +73,103 @@ class TestSMCQuantification(unittest.TestCase):
 
         assumption_ratio = 0.5 * 1.1 * 1.5
         pop_0_5 = self.mock_population_data["pop_0_5"][0]
+        expected_quantity_3_11 = pop_0_5 * 0.6 * assumption_ratio
+        expected_quantity_12_59 = pop_0_5 * 0.3 * assumption_ratio
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        result_3_11 = result[result["unit"] == "per SPAQ pack 3-11 month olds"].iloc[0]
+
+        self.assertAlmostEqual(result_3_11["quantity"], expected_quantity_3_11)
+        self.assertAlmostEqual(
+            result_3_11["target_pop"],
+            pop_0_5 * (0.6 + 0.3) * 0.5,
+        )
+
+        result_12_59 = result[result["unit"] == "per SPAQ pack 12-59 month olds"].iloc[
+            0
+        ]
+        self.assertAlmostEqual(result_12_59["quantity"], expected_quantity_12_59)
+        self.assertAlmostEqual(
+            result_12_59["target_pop"],
+            pop_0_5 * (0.3 + 0.6) * 0.5,
+        )
+
+    def test_smc_quantification_custom_target_population(self):
+        """Test that SMCQuantification returns expected results for a known code."""
+
+        quant = SMCQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "smc_coverage": 0.5,
+                "smc_buffer_mult": 1.1,
+                "smc_monthly_rounds": 1.5,
+                "smc_pop_prop_3_11": 0.6,
+                "smc_pop_prop_12_59": 0.3,
+            },
+        )
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_smc"] = [["pop_0_5_custom"]]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        assumption_ratio = 0.5 * 1.1 * 1.5
+        pop_0_5 = self.mock_population_data["pop_0_5_custom"][0]
+        expected_quantity_3_11 = pop_0_5 * 0.6 * assumption_ratio
+        expected_quantity_12_59 = pop_0_5 * 0.3 * assumption_ratio
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        result_3_11 = result[result["unit"] == "per SPAQ pack 3-11 month olds"].iloc[0]
+
+        self.assertAlmostEqual(result_3_11["quantity"], expected_quantity_3_11)
+        self.assertAlmostEqual(
+            result_3_11["target_pop"],
+            pop_0_5 * (0.6 + 0.3) * 0.5,
+        )
+
+        result_12_59 = result[result["unit"] == "per SPAQ pack 12-59 month olds"].iloc[
+            0
+        ]
+        self.assertAlmostEqual(result_12_59["quantity"], expected_quantity_12_59)
+        self.assertAlmostEqual(
+            result_12_59["target_pop"],
+            pop_0_5 * (0.3 + 0.6) * 0.5,
+        )
+
+    def test_smc_quantification_multiple_custom_target_population(self):
+        """Test that SMCQuantification returns expected results for a known code."""
+
+        quant = SMCQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "smc_coverage": 0.5,
+                "smc_buffer_mult": 1.1,
+                "smc_monthly_rounds": 1.5,
+                "smc_pop_prop_3_11": 0.6,
+                "smc_pop_prop_12_59": 0.3,
+            },
+        )
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_smc"] = [
+            ["pop_0_5_custom", "pop_0_5_custom_2"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        assumption_ratio = 0.5 * 1.1 * 1.5
+        pop_0_5 = (
+            self.mock_population_data["pop_0_5_custom"][0]
+            + self.mock_population_data["pop_0_5_custom_2"][0]
+        )
         expected_quantity_3_11 = pop_0_5 * 0.6 * assumption_ratio
         expected_quantity_12_59 = pop_0_5 * 0.3 * assumption_ratio
 

--- a/tests/core/quantification_functions/test_vacc_quantification.py
+++ b/tests/core/quantification_functions/test_vacc_quantification.py
@@ -35,7 +35,9 @@ class TestVaccQuantification(unittest.TestCase):
                 "adm1": [admin1],
                 "adm2": [admin2],
                 "year": [year],
-                "pop_vaccine_5_36_months": [342988.7383],
+                "pop_vaccine_5_36_months": [32988.7383],
+                "pop_vaccine_5_36_months_custom": [32088.7383],
+                "pop_vaccine_5_36_months_custom_2": [30988.7383],
             }
         )
 
@@ -78,6 +80,96 @@ class TestVaccQuantification(unittest.TestCase):
         expected_quantity_per_child = (
             self.mock_population_data["pop_vaccine_5_36_months"][0] * 0.5
         )
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        dose_result = result[result["unit"] == "per dose"].iloc[0]
+
+        self.assertAlmostEqual(dose_result["quantity"], expected_quantity_per_dose)
+        self.assertAlmostEqual(
+            dose_result["target_pop"],
+            expected_quantity_per_child,
+        )
+
+        child_result = result[result["unit"] == "per child"].iloc[0]
+        self.assertAlmostEqual(child_result["quantity"], expected_quantity_per_child)
+        self.assertAlmostEqual(child_result["target_pop"], expected_quantity_per_child)
+
+    def test_vacc_quantification_custom_target_population(self):
+        """Test that VaccQuantification returns expected results for a known code."""
+
+        quant = VaccQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "vacc_coverage": 0.5,
+                "vacc_buffer_mult": 1.1,
+                "vacc_doses_per_child": 3,
+            },
+        )
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_vacc"] = [
+            ["pop_vaccine_5_36_months_custom"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+
+        expected_quantity_per_dose = (
+            self.mock_population_data["pop_vaccine_5_36_months_custom"][0]
+            * 0.5
+            * 1.1
+            * 3
+        )
+
+        expected_quantity_per_child = (
+            self.mock_population_data["pop_vaccine_5_36_months_custom"][0] * 0.5
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("quantity", result.columns)
+        self.assertIn("target_pop", result.columns)
+        self.assertIn("code_intervention", result.columns)
+        self.assertIn("type_intervention", result.columns)
+        self.assertIn("unit", result.columns)
+
+        dose_result = result[result["unit"] == "per dose"].iloc[0]
+
+        self.assertAlmostEqual(dose_result["quantity"], expected_quantity_per_dose)
+        self.assertAlmostEqual(
+            dose_result["target_pop"],
+            expected_quantity_per_child,
+        )
+
+        child_result = result[result["unit"] == "per child"].iloc[0]
+        self.assertAlmostEqual(child_result["quantity"], expected_quantity_per_child)
+        self.assertAlmostEqual(child_result["target_pop"], expected_quantity_per_child)
+
+    def test_vacc_quantification_multiple_custom_target_population(self):
+        """Test that VaccQuantification returns expected results for a known code."""
+
+        quant = VaccQuantification(
+            spatial_unit="adm2",
+            assumptions={
+                "vacc_coverage": 0.5,
+                "vacc_buffer_mult": 1.1,
+                "vacc_doses_per_child": 3,
+            },
+        )
+        scen_data = self.scen_data.copy()
+        scen_data["target_population_columns_vacc"] = [
+            ["pop_vaccine_5_36_months_custom", "pop_vaccine_5_36_months_custom_2"]
+        ]
+        result = quant.get_quantification(scen_data, self.mock_population_data)
+        target_pop_sum = (
+            self.mock_population_data["pop_vaccine_5_36_months_custom"][0]
+            + self.mock_population_data["pop_vaccine_5_36_months_custom_2"][0]
+        )
+        expected_quantity_per_dose = target_pop_sum * 0.5 * 1.1 * 3
+
+        expected_quantity_per_child = target_pop_sum * 0.5
 
         self.assertEqual(len(result), 2)
         self.assertIn("quantity", result.columns)

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -600,6 +600,8 @@ class TestGetBudget(unittest.TestCase):
         self.assertEqual(len(places_costs), 2)
         unknown = next(i for i in interventions_costs if i["type"] == "NKWN")
         self.assertEqual(unknown["code"], "unknown")
+        # This cost from uknown intervention, taking the total population for place 1001 assigned: 250000
+        # multiplied by the default unknown intervention cost per person of 3 usd, and then multiplied by the default buffer of 1
         self.assertEqual(unknown["total_cost"], 750000)
         self.assertEqual(unknown["total_pop"], POP_TOTAL)
         self.assertEqual(len(unknown["cost_breakdown"]), 1)
@@ -817,9 +819,11 @@ class TestGetBudget(unittest.TestCase):
 
         self.assertEqual(len(interventions_costs), 3)
 
-        iptp = next(i for i in interventions_costs if i["type"] == "SP")
-        smc = next(i for i in interventions_costs if i["type"] == "SP+AQ")
-        unknown = next(i for i in interventions_costs if i["type"] == "NKWN")
+        interventions_reults = {i["type"]: i for i in interventions_costs}
+
+        iptp = interventions_reults["SP"]
+        smc = interventions_reults["SP+AQ"]
+        unknown = interventions_reults["NKWN"]
 
         correct_iptp_pop_location_1001 = POP_0_1 * 1.5
         correct_iptp_pop_location_1002 = POP_0_1 * 2.5
@@ -881,16 +885,16 @@ class TestGetBudget(unittest.TestCase):
         self.assertEqual(smc["cost_breakdown"][0]["cost_class"], "Commodity")
         self.assertAlmostEqual(smc["cost_breakdown"][0]["cost"], correct_smc_cost)
 
-        unknown = next(i for i in interventions_costs if i["type"] == "NKWN")
         self.assertEqual(unknown["total_pop"], 0)
         self.assertEqual(unknown["total_cost"], 0)
         self.assertEqual(unknown["type"], "NKWN")
         self.assertEqual(unknown["code"], "unknown")
         self.assertEqual(len(unknown["cost_breakdown"]), 0)
 
-        place_1001 = next(
-            place_cost for place_cost in places_costs if place_cost["place"] == 1001
-        )
+        places_result = {p["place"]: p for p in places_costs}
+
+        place_1001 = places_result[1001]
+        place_1002 = places_result[1002]
         self.assertAlmostEqual(
             place_1001["total_cost"], correct_iptp_cost_location_1001
         )
@@ -907,9 +911,6 @@ class TestGetBudget(unittest.TestCase):
             place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1001
         )
 
-        place_1002 = next(
-            place_cost for place_cost in places_costs if place_cost["place"] == 1002
-        )
         self.assertAlmostEqual(
             place_1002["total_cost"], correct_iptp_cost_location_1002 + correct_smc_cost
         )

--- a/tests/core/test_budget_calculator.py
+++ b/tests/core/test_budget_calculator.py
@@ -34,6 +34,8 @@ class TestGetBudget(unittest.TestCase):
                     POP_VACCINE_5_36_MONTHS,
                     POP_VACCINE_5_36_MONTHS * 2,
                 ],
+                "custom_pop_1": [POP_0_1 * 1.5, POP_0_1 * 2.5, POP_0_1, POP_0_1 * 2.5],
+                "custom_pop_2": [POP_1_2 * 1.5, POP_1_2 * 2.5, POP_1_2, POP_1_2 * 3.5],
             }
         )
 
@@ -571,7 +573,7 @@ class TestGetBudget(unittest.TestCase):
             {
                 "code_intervention": ["unknown"],
                 "type_intervention": ["NKWN"],
-                "unit": ["per dose"],
+                "unit": ["Other"],
                 "cost_class": ["Commodity"],
                 "cost_year_for_analysis": [2025],
                 "usd_cost": [3.00],
@@ -594,8 +596,15 @@ class TestGetBudget(unittest.TestCase):
         interventions_costs = budget_calculator.get_interventions_costs(2025)
         places_costs = budget_calculator.get_places_costs(2025)
 
-        self.assertEqual(len(interventions_costs), 0)
-        self.assertEqual(len(places_costs), 0)
+        self.assertEqual(len(interventions_costs), 1)
+        self.assertEqual(len(places_costs), 2)
+        unknown = next(i for i in interventions_costs if i["type"] == "NKWN")
+        self.assertEqual(unknown["code"], "unknown")
+        self.assertEqual(unknown["total_cost"], 750000)
+        self.assertEqual(unknown["total_pop"], POP_TOTAL)
+        self.assertEqual(len(unknown["cost_breakdown"]), 1)
+        self.assertEqual(unknown["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertEqual(unknown["cost_breakdown"][0]["cost"], 750000)
 
     def test_get_budget_multiple_interventions(self):
         interventions = [
@@ -690,6 +699,177 @@ class TestGetBudget(unittest.TestCase):
             * DEFAULT_COST_ASSUMPTIONS["smc_monthly_rounds"]
             * DEFAULT_COST_ASSUMPTIONS["smc_buffer_mult"]
         ) * 2  # Doubled for location 1002
+
+        correct_smc_cost = correct_smc_cost_3_11 + correct_smc_cost_12_59
+
+        self.assertAlmostEqual(smc["total_pop"], correct_smc_target_pop)
+        self.assertAlmostEqual(smc["total_cost"], correct_smc_cost)
+        self.assertEqual(smc["type"], "SP+AQ")
+        self.assertEqual(smc["code"], "smc")
+        self.assertEqual(len(smc["cost_breakdown"]), 1)
+        self.assertEqual(smc["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(smc["cost_breakdown"][0]["cost"], correct_smc_cost)
+
+        unknown = next(i for i in interventions_costs if i["type"] == "NKWN")
+        self.assertEqual(unknown["total_pop"], 0)
+        self.assertEqual(unknown["total_cost"], 0)
+        self.assertEqual(unknown["type"], "NKWN")
+        self.assertEqual(unknown["code"], "unknown")
+        self.assertEqual(len(unknown["cost_breakdown"]), 0)
+
+        place_1001 = next(
+            place_cost for place_cost in places_costs if place_cost["place"] == 1001
+        )
+        self.assertAlmostEqual(
+            place_1001["total_cost"], correct_iptp_cost_location_1001
+        )
+        self.assertEqual(len(place_1001["interventions"]), 1)
+        place_iptp = place_1001["interventions"][0]
+        self.assertEqual(place_iptp["type"], "SP")
+        self.assertEqual(place_iptp["code"], "iptp")
+        self.assertAlmostEqual(
+            place_iptp["total_cost"], correct_iptp_cost_location_1001
+        )
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1001
+        )
+
+        place_1002 = next(
+            place_cost for place_cost in places_costs if place_cost["place"] == 1002
+        )
+        self.assertAlmostEqual(
+            place_1002["total_cost"], correct_iptp_cost_location_1002 + correct_smc_cost
+        )
+        self.assertEqual(len(place_1002["interventions"]), 2)
+        place_iptp = place_1002["interventions"][0]
+        self.assertEqual(place_iptp["type"], "SP")
+        self.assertEqual(place_iptp["code"], "iptp")
+        self.assertAlmostEqual(
+            place_iptp["total_cost"], correct_iptp_cost_location_1002
+        )
+        self.assertEqual(len(place_iptp["cost_breakdown"]), 1)
+        self.assertEqual(place_iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(
+            place_iptp["cost_breakdown"][0]["cost"], correct_iptp_cost_location_1002
+        )
+        place_smc = place_1002["interventions"][1]
+        self.assertEqual(place_smc["type"], "SP+AQ")
+        self.assertEqual(place_smc["code"], "smc")
+        self.assertAlmostEqual(place_smc["total_cost"], correct_smc_cost)
+        self.assertEqual(len(place_smc["cost_breakdown"]), 1)
+        self.assertEqual(place_smc["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(place_smc["cost_breakdown"][0]["cost"], correct_smc_cost)
+
+    def test_get_budget_custom_population(self):
+        interventions = [
+            InterventionDetailModel(
+                code="iptp",
+                type="SP",
+                places=[1001, 1002],
+                target_population_columns=["custom_pop_1"],
+            ),
+            InterventionDetailModel(
+                code="smc",
+                type="SP+AQ",
+                places=[1002],
+                target_population_columns=["custom_pop_2"],
+            ),
+            InterventionDetailModel(
+                code="unknown",
+                type="NKWN",
+                places=[1001, 1002],
+                target_population_columns=["custom_pop_1", "custom_pop_2"],
+            ),
+        ]
+
+        cost_df = pd.DataFrame(
+            {
+                "code_intervention": ["iptp", "smc", "smc"],
+                "type_intervention": ["SP", "SP+AQ", "SP+AQ"],
+                "unit": [
+                    "per SP",
+                    "per SPAQ pack 3-11 month olds",
+                    "per SPAQ pack 12-59 month olds",
+                ],
+                "cost_class": ["Commodity", "Commodity", "Commodity"],
+                "cost_year_for_analysis": [2025, 2025, 2025],
+                "usd_cost": [0.50558094, 0.29, 0.35],
+                "local_currency_cost": [1, 480.0, 480.0],
+                "cost_name": ["test", "test", "test"],
+            }
+        )
+
+        budget_calculator = BudgetCalculator(
+            interventions_input=interventions,
+            settings=DEFAULT_COST_ASSUMPTIONS,
+            cost_df=cost_df,
+            population_df=self.population_df,
+            local_currency="ngn",
+            spatial_planning_unit="key",
+            budget_currency="usd",
+            unknown_intervention_handling=UnknownInterventionHandling.HANDLE,
+        )
+
+        interventions_costs = budget_calculator.get_interventions_costs(2025)
+        places_costs = budget_calculator.get_places_costs(2025)
+
+        self.assertEqual(len(interventions_costs), 3)
+
+        iptp = next(i for i in interventions_costs if i["type"] == "SP")
+        smc = next(i for i in interventions_costs if i["type"] == "SP+AQ")
+        unknown = next(i for i in interventions_costs if i["type"] == "NKWN")
+
+        correct_iptp_pop_location_1001 = POP_0_1 * 1.5
+        correct_iptp_pop_location_1002 = POP_0_1 * 2.5
+        correct_iptp_target_pop = (
+            correct_iptp_pop_location_1001 + correct_iptp_pop_location_1002
+        )
+        correct_iptp_cost = (
+            correct_iptp_target_pop * 0.8 * 3 * 1.1 * 0.50558094
+        )  # mutliplied by usd_cost
+
+        correct_iptp_cost_location_1001 = (
+            correct_iptp_pop_location_1001 * 0.8 * 3 * 1.1 * 0.50558094
+        )
+        correct_iptp_cost_location_1002 = (
+            correct_iptp_pop_location_1002 * 0.8 * 3 * 1.1 * 0.50558094
+        )
+
+        self.assertAlmostEqual(iptp["total_pop"], correct_iptp_target_pop)
+        self.assertAlmostEqual(iptp["total_cost"], correct_iptp_cost)
+        self.assertEqual(iptp["type"], "SP")
+        self.assertEqual(iptp["code"], "iptp")
+        self.assertEqual(len(iptp["cost_breakdown"]), 1)
+        self.assertEqual(iptp["cost_breakdown"][0]["cost_class"], "Commodity")
+        self.assertAlmostEqual(iptp["cost_breakdown"][0]["cost"], correct_iptp_cost)
+
+        correct_smc_target_pop = (
+            POP_1_2
+            * (
+                DEFAULT_COST_ASSUMPTIONS["smc_pop_prop_3_11"]
+                + DEFAULT_COST_ASSUMPTIONS["smc_pop_prop_12_59"]
+            )
+            * DEFAULT_COST_ASSUMPTIONS["smc_coverage"]
+        ) * 2.5  # Doubled for location 1002
+
+        correct_smc_cost_3_11 = (
+            0.29
+            * POP_1_2
+            * DEFAULT_COST_ASSUMPTIONS["smc_pop_prop_3_11"]
+            * DEFAULT_COST_ASSUMPTIONS["smc_coverage"]
+            * DEFAULT_COST_ASSUMPTIONS["smc_monthly_rounds"]
+            * DEFAULT_COST_ASSUMPTIONS["smc_buffer_mult"]
+        ) * 2.5  # Doubled for location 1002
+        correct_smc_cost_12_59 = (
+            0.35
+            * POP_1_2
+            * DEFAULT_COST_ASSUMPTIONS["smc_pop_prop_12_59"]
+            * DEFAULT_COST_ASSUMPTIONS["smc_coverage"]
+            * DEFAULT_COST_ASSUMPTIONS["smc_monthly_rounds"]
+            * DEFAULT_COST_ASSUMPTIONS["smc_buffer_mult"]
+        ) * 2.5  # Doubled for location 1002
 
         correct_smc_cost = correct_smc_cost_3_11 + correct_smc_cost_12_59
 


### PR DESCRIPTION
Accept a new **optional** property on `interventions_input` to allow to target custom population.

It accepts an array of string which should be part of the `population dataframe` columns.

For most interventions, if many are specified, it will sum them up.
For `smc` it has to contain exactly two items, this is because of the way quantification is calculated.

Also updated the readme to give a bit more context and explanation.

**How to test**

You can add `target_population_columns` to any InterventionDetailsModel and verify that it is using that population instead of the default one and that it doesn't crash.

**Breaking changes**

Took the liberty to remove custom mapping which was not obvious and flexible at all.
Which means that if you were relying on it, it will need to end up in your `target_population_columns` and as column name in your `population_df`

As a quick reference, here was the mapping:

```
"Total population": ["pop_total"],
"Children under 5": ["pop_0_5"],
"Children under 5 and pregnant women": ["pop_0_5", "pop_pw"],
"Children under 10": ["pop_0_5", "pop_5_10"],
"Children 0-1": ["pop_0_1"],
"Children 1-2": ["pop_1_2"],
"Pregnant women": ["pop_pw"],
```

